### PR TITLE
SLING-8710: IndexingClient should have configurable lanes

### DIFF
--- a/src/main/java/org/apache/sling/testing/clients/indexing/IndexingClient.java
+++ b/src/main/java/org/apache/sling/testing/clients/indexing/IndexingClient.java
@@ -181,7 +181,7 @@ public class IndexingClient extends SlingClient {
      * @param laneNames lane names to work on
      */
     public void setLaneNames(String ... laneNames) {
-        getValues().put(INDEX_LANES_CSV_CONFIG_NAME, StringUtils.join(laneNames));
+        getValues().put(INDEX_LANES_CSV_CONFIG_NAME, StringUtils.join(laneNames, ','));
     }
 
     /**

--- a/src/test/java/org/apache/sling/testing/clients/indexing/IndexingClientTest.java
+++ b/src/test/java/org/apache/sling/testing/clients/indexing/IndexingClientTest.java
@@ -27,6 +27,7 @@ import org.apache.http.protocol.HttpRequestHandler;
 import org.apache.sling.testing.clients.ClientException;
 import org.apache.sling.testing.clients.HttpServerRule;
 import org.apache.sling.testing.clients.query.servlet.QueryServlet;
+import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -46,7 +47,7 @@ public class IndexingClientTest {
     private static final String EXPLAIN_RESPONSE = "{\"plan\": \"random plan with testIndexingLane-async and testIndexingLane-fulltext-async\",\"time\": 1}";
     private static final String QUERY_RESPONSE = "{\"total\": 1234,\"time\": 1}";
 
-    private static final String [] PRE_DEFINED_INDEXING_LANES = new String[]{"async, fulltext-async"};
+    private static final String [] PRE_DEFINED_INDEXING_LANES = new String[]{"async", "fulltext-async"};
 
     private static final AtomicInteger NUM_INDEXING_LANE_CONSOLE_CALLS = new AtomicInteger();
 
@@ -210,9 +211,19 @@ public class IndexingClientTest {
     @Test
     public void testWaitForAsyncIndexing_ConfiguredLanes() throws ClientException, TimeoutException, InterruptedException {
         client.setLaneNames(PRE_DEFINED_INDEXING_LANES);
+
+        List<String> retrievedLaneNames = client.getLaneNames();
+        Assert.assertEquals("Mismatched number of lanes", PRE_DEFINED_INDEXING_LANES.length, retrievedLaneNames.size());
+        Assert.assertThat(retrievedLaneNames, CoreMatchers.hasItems(PRE_DEFINED_INDEXING_LANES));
+
         client.waitForAsyncIndexing();
 
         IndexingClient otherClient = client.adaptTo(IndexingClient.class);
+
+        retrievedLaneNames = otherClient.getLaneNames();
+        Assert.assertEquals("Mismatched number of lanes", PRE_DEFINED_INDEXING_LANES.length, retrievedLaneNames.size());
+        Assert.assertThat(retrievedLaneNames, CoreMatchers.hasItems(PRE_DEFINED_INDEXING_LANES));
+
         otherClient.waitForAsyncIndexing();
 
         Assert.assertEquals("Must not get indexing lanes from /system/console",


### PR DESCRIPTION
Was storing lane names incorrectly which got missed in the test case
because test lanes names was incorrectly set to an array of single
string with comma in the string while it should have been an array of
two separate strings.