### PR TITLE
SLING-8921 requestPath must to be encoded in SlingClient#doGet()

### DIFF
--- a/src/main/java/org/apache/sling/testing/clients/AbstractSlingClient.java
+++ b/src/main/java/org/apache/sling/testing/clients/AbstractSlingClient.java
@@ -33,8 +33,6 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;

--- a/src/main/java/org/apache/sling/testing/clients/AbstractSlingClient.java
+++ b/src/main/java/org/apache/sling/testing/clients/AbstractSlingClient.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -133,8 +134,9 @@ public class AbstractSlingClient implements HttpClient, Closeable {
      */
     public URI getUrl(String path) {
         try {
-            URI pathUri = slash.relativize(new URI(path));
-            return getUrl().resolve(pathUri);
+            URI pathUri = new URI(null, null, path, null);
+            URI relative = slash.relativize(pathUri);
+            return getUrl().resolve(relative);
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException(e);
         }

--- a/src/test/java/org/apache/sling/testing/AbstractSlingClientGetUrlTest.java
+++ b/src/test/java/org/apache/sling/testing/AbstractSlingClientGetUrlTest.java
@@ -106,6 +106,9 @@ public class AbstractSlingClientGetUrlTest {
                 // External URLs
                 {"http://HOST:4502/CTX/",    "http://www.google.com", "http://www.google.com"},
                 {"http://HOST:4502/CTX/",    "http://HOST:4502/CTX/my/page.html", "http://HOST:4502/CTX/my/page.html"},
+
+                // URL encoding of the path
+                {"http://HOST:4502/CTX/",    "!@*()'~ #$%^&{}[]|\\<>?\"`", "http://host:4502/CTX/!@*()'~%20%23$%25%5E&%7B%7D%5B%5D%7C%5C%3C%3E%3F%22%60"},
         });
     }
 


### PR DESCRIPTION
- getUrl() implementation changed that it attempts to treat path
  parameter as URI path as it is defined by
  java.net.URI(String, String, String, String) constructor

This change affects the behavior of all methods in doGet as well as doStream family that take requestPath as a separate parameter.

Note that this change brakes compatibility with https://github.com/adobe/aem-test-samples/commit/cf6c1685102f2487de359d705a868ca9659b7986 commit and it should be reverted in order for the smoke tests to continue to work.