### PR TITLE
Support for impersonation

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,3 +214,7 @@ We have tried to make these methods as robust as possible. Their job is very cle
 
 Any input that does not respect the contract might not work. Check `AbstractSlingClientGetPathTest` and `AbstractSlingClientGetUrlTest`
 for an extensive list of cases that we have considered when writing these methods.
+
+##### How can I impersonate a user?
+* `client.impersonate(userId)` to impersonate
+* `client.impersonate(null)` to clear impersonation

--- a/src/main/java/org/apache/sling/testing/clients/SlingClient.java
+++ b/src/main/java/org/apache/sling/testing/clients/SlingClient.java
@@ -61,7 +61,7 @@ import static org.apache.http.HttpStatus.SC_OK;
 public class SlingClient extends AbstractSlingClient {
 
     public static final String DEFAULT_NODE_TYPE = "sling:OrderedFolder";
-    private static String SUDO_COOKIE = "sling.sudo";
+    public static final String SUDO_COOKIE = "sling.sudo";
 
     /**
      * Constructor used by Builders and adaptTo(). <b>Should never be called directly from the code.</b>

--- a/src/main/java/org/apache/sling/testing/clients/email/package-info.java
+++ b/src/main/java/org/apache/sling/testing/clients/email/package-info.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-@Version("1.2.0")
+@Version("1.3.0")
 package org.apache.sling.testing.clients.email;
 
 import org.osgi.annotation.versioning.Version;

--- a/src/main/java/org/apache/sling/testing/clients/html/package-info.java
+++ b/src/main/java/org/apache/sling/testing/clients/html/package-info.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-@Version("2.3.0")
+@Version("2.4.0")
 package org.apache.sling.testing.clients.html;
 
 import org.osgi.annotation.versioning.Version;

--- a/src/main/java/org/apache/sling/testing/clients/indexing/package-info.java
+++ b/src/main/java/org/apache/sling/testing/clients/indexing/package-info.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-@Version("0.2.0")
+@Version("0.3.0")
 package org.apache.sling.testing.clients.indexing;
 
 import org.osgi.annotation.versioning.Version;

--- a/src/main/java/org/apache/sling/testing/clients/osgi/package-info.java
+++ b/src/main/java/org/apache/sling/testing/clients/osgi/package-info.java
@@ -19,7 +19,7 @@
 /**
  * OSGI testing tools.
  */
-@Version("2.0.0")
+@Version("2.1.0")
 package org.apache.sling.testing.clients.osgi;
 
 import org.osgi.annotation.versioning.Version;

--- a/src/main/java/org/apache/sling/testing/clients/package-info.java
+++ b/src/main/java/org/apache/sling/testing/clients/package-info.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-@Version("1.5.0")
+@Version("1.6.0")
 package org.apache.sling.testing.clients;
 
 import org.osgi.annotation.versioning.Version;

--- a/src/main/java/org/apache/sling/testing/clients/package-info.java
+++ b/src/main/java/org/apache/sling/testing/clients/package-info.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-@Version("1.6.0")
+@Version("1.7.0")
 package org.apache.sling.testing.clients;
 
 import org.osgi.annotation.versioning.Version;

--- a/src/main/java/org/apache/sling/testing/clients/query/package-info.java
+++ b/src/main/java/org/apache/sling/testing/clients/query/package-info.java
@@ -19,7 +19,7 @@
 /**
  * Query tools leveraging javax.jcr.query
  */
-@Version("0.1.0")
+@Version("0.2.0")
 package org.apache.sling.testing.clients.query;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
In my project I have many tests where I need to impersonate users with different permissions and test from those users eye view.  This patch adds support for SlingClient#impersonate(String userId) method .

A few use cases for SlingClient#impersonate(String userId)  would be:
- validate CRUD access 
 - validate that the server respect users privileges when generating component html, e.g. when validating AEM Touch UI 
- start a workflow and assert that depending on user permissions it will or will not step in the 'approval'  step. 

