### PR TITLE
SLING-11125 Fix SlingClient.exists(..) calls when retriesErrorCodes i…

### DIFF
--- a/src/main/java/org/apache/sling/testing/Constants.java
+++ b/src/main/java/org/apache/sling/testing/Constants.java
@@ -37,4 +37,10 @@ public class Constants {
      * Http Context Attributes
      */
     public static final String EXPECTED_STATUS = "expected_status";
+
+    /**
+     * ClientException expected status prefix
+     */
+    public static final String EXPECTED_STATUS_ERROR_PREFIX = "Expected HTTP Status: ";
+
 }

--- a/src/main/java/org/apache/sling/testing/clients/SlingClient.java
+++ b/src/main/java/org/apache/sling/testing/clients/SlingClient.java
@@ -71,6 +71,7 @@ public class SlingClient extends AbstractSlingClient {
     public static final String DEFAULT_NODE_TYPE = "sling:OrderedFolder";
     public static final String CLIENT_CONNECTION_TIMEOUT_PROP = "sling.client.connection.timeout.seconds";
     public static final String SUDO_COOKIE_NAME = "sling.sudo.cookie.name";
+    public static final String JSON_EXT = ".json";
 
     /**
      * Constructor used by Builders and adaptTo(). <b>Should never be called directly from the code.</b>
@@ -204,7 +205,7 @@ public class SlingClient extends AbstractSlingClient {
      */
     public boolean exists(String path) throws ClientException {
         try {
-            SlingHttpResponse response = this.doGet(path + ".json", SC_OK, SC_NOT_FOUND);
+            SlingHttpResponse response = this.doGet(path + JSON_EXT, SC_OK, SC_NOT_FOUND);
             final int status = response.getStatusLine().getStatusCode();
             return status == SC_OK;
         } catch (ClientException exc) {
@@ -409,7 +410,7 @@ public class SlingClient extends AbstractSlingClient {
         if (depth == -1) {
             path += ".infinity.json";
         } else {
-            path += "." + depth + ".json";
+            path += "." + depth + JSON_EXT;
         }
 
         // request the JSON for the page node
@@ -436,7 +437,7 @@ public class SlingClient extends AbstractSlingClient {
         if (depth == -1) {
             path += ".infinity.json";
         } else {
-            path += "." + depth + ".json";
+            path += "." + depth + JSON_EXT;
         }
 
         // request the JSON for the node

--- a/src/main/java/org/apache/sling/testing/clients/SlingClient.java
+++ b/src/main/java/org/apache/sling/testing/clients/SlingClient.java
@@ -17,7 +17,9 @@
 package org.apache.sling.testing.clients;
 
 import static org.apache.http.HttpStatus.SC_CREATED;
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.http.HttpStatus.SC_OK;
+import static org.apache.sling.testing.Constants.EXPECTED_STATUS_ERROR_PREFIX;
 
 import java.io.File;
 import java.net.URI;
@@ -201,9 +203,19 @@ public class SlingClient extends AbstractSlingClient {
      * @throws ClientException if the request could not be performed
      */
     public boolean exists(String path) throws ClientException {
-        SlingHttpResponse response = this.doGet(path + ".json");
-        final int status = response.getStatusLine().getStatusCode();
-        return status == SC_OK;
+        try {
+            SlingHttpResponse response = this.doGet(path + ".json", SC_OK, SC_NOT_FOUND);
+            final int status = response.getStatusLine().getStatusCode();
+            return status == SC_OK;
+        } catch (ClientException exc) {
+            if (exc.getMessage().startsWith(EXPECTED_STATUS_ERROR_PREFIX)) {
+                // none of the expected status, so false
+                return false;
+            } else {
+                // not an expected status issue re-throw
+                throw exc;
+            }
+        }
     }
 
     /**

--- a/src/main/java/org/apache/sling/testing/clients/SlingClient.java
+++ b/src/main/java/org/apache/sling/testing/clients/SlingClient.java
@@ -71,7 +71,8 @@ public class SlingClient extends AbstractSlingClient {
     public static final String DEFAULT_NODE_TYPE = "sling:OrderedFolder";
     public static final String CLIENT_CONNECTION_TIMEOUT_PROP = "sling.client.connection.timeout.seconds";
     public static final String SUDO_COOKIE_NAME = "sling.sudo.cookie.name";
-    public static final String JSON_EXT = ".json";
+
+    private static final String JSON_EXT = ".json";
 
     /**
      * Constructor used by Builders and adaptTo(). <b>Should never be called directly from the code.</b>

--- a/src/main/java/org/apache/sling/testing/clients/util/HttpUtils.java
+++ b/src/main/java/org/apache/sling/testing/clients/util/HttpUtils.java
@@ -16,6 +16,8 @@
  */
 package org.apache.sling.testing.clients.util;
 
+import static org.apache.sling.testing.Constants.EXPECTED_STATUS_ERROR_PREFIX;
+
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.sling.testing.clients.ClientException;
@@ -85,7 +87,7 @@ public class HttpUtils {
     private static boolean throwError(HttpResponse response, String errorMessage, int... expectedStatus)
             throws ClientException {
         // build error message
-        String errorMsg = "Expected HTTP Status: ";
+        String errorMsg = EXPECTED_STATUS_ERROR_PREFIX;
         for (int expected : expectedStatus) {
             errorMsg += expected + " ";
         }

--- a/src/test/java/org/apache/sling/testing/clients/SlingClientRetryStrategyTest.java
+++ b/src/test/java/org/apache/sling/testing/clients/SlingClientRetryStrategyTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.sling.testing.clients;
 
+import java.net.URI;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.protocol.HttpRequestHandler;
 import org.hamcrest.CoreMatchers;
@@ -170,6 +171,12 @@ public class SlingClientRetryStrategyTest {
         SlingClient c = new SlingClient(httpServer.getURI(), "user", "pass");
         assertFalse(c.exists(GET_INEXISTENT_PATH));
         assertEquals(1, requestCount);
+    }
+
+    @Test(expected = ClientException.class)
+    public void testExistOtherClientException() throws Exception {
+        SlingClient c = new SlingClient(new URI("http://dummy:1234"), "user", "pass");
+        c.exists("/any/resource");
     }
 
     @Test


### PR DESCRIPTION
…nclude 404

As described on SLING-11125 this PR aim to fix the issue that may occurs when allowing retries on 404 , and SlingClient.exists(..) is called with 404 expected.
