### PR TITLE
SLING-11131 - Update Apache HTTP Client Dependency for CVE-2020-13956

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,12 +106,12 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.4.1</version>
+            <version>4.5.13</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpmime</artifactId>
-            <version>4.4.1</version>
+            <version>4.5.13</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/src/main/java/org/apache/sling/testing/clients/AbstractSlingClient.java
+++ b/src/main/java/org/apache/sling/testing/clients/AbstractSlingClient.java
@@ -17,7 +17,8 @@
 package org.apache.sling.testing.clients;
 
 import org.apache.http.*;
-import org.apache.http.annotation.Immutable;
+import org.apache.http.annotation.Contract;
+import org.apache.http.annotation.ThreadingBehavior;
 import org.apache.http.client.*;
 import org.apache.http.client.methods.*;
 import org.apache.http.client.protocol.HttpClientContext;
@@ -42,7 +43,7 @@ import static org.apache.sling.testing.Constants.EXPECTED_STATUS;
 /**
  * The abstract base client for all implementing integration test clients.
  */
-@Immutable
+@Contract(threading = ThreadingBehavior.IMMUTABLE)
 public class AbstractSlingClient implements HttpClient, Closeable {
 
     private final org.slf4j.Logger log = LoggerFactory.getLogger(getClass());

--- a/src/main/java/org/apache/sling/testing/clients/SlingClient.java
+++ b/src/main/java/org/apache/sling/testing/clients/SlingClient.java
@@ -34,7 +34,8 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.HttpResponseInterceptor;
 import org.apache.http.NameValuePair;
-import org.apache.http.annotation.Immutable;
+import org.apache.http.annotation.Contract;
+import org.apache.http.annotation.ThreadingBehavior;
 import org.apache.http.client.CookieStore;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.RedirectStrategy;
@@ -63,7 +64,7 @@ import org.apache.sling.testing.timeouts.TimeoutsProvider;
  * <p>It has methods to perform simple node operations on the server like creating and deleting nodes, etc.
  * on the server using requests. </p>
  */
-@Immutable
+@Contract(threading = ThreadingBehavior.IMMUTABLE)
 public class SlingClient extends AbstractSlingClient {
 
     public static final String DEFAULT_NODE_TYPE = "sling:OrderedFolder";

--- a/src/main/java/org/apache/sling/testing/clients/SlingClientConfig.java
+++ b/src/main/java/org/apache/sling/testing/clients/SlingClientConfig.java
@@ -18,7 +18,8 @@ package org.apache.sling.testing.clients;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHost;
-import org.apache.http.annotation.ThreadSafe;
+import org.apache.http.annotation.Contract;
+import org.apache.http.annotation.ThreadingBehavior;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.AuthCache;
@@ -36,7 +37,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
-@ThreadSafe
+@Contract(threading = ThreadingBehavior.SAFE)
 public class SlingClientConfig {
 
     /**

--- a/src/main/java/org/apache/sling/testing/clients/package-info.java
+++ b/src/main/java/org/apache/sling/testing/clients/package-info.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-@Version("3.0.0")
+@Version("3.0.1")
 package org.apache.sling.testing.clients;
 
 import org.osgi.annotation.versioning.Version;

--- a/src/test/java/org/apache/sling/testing/AbstractSlingClientGetUrlTest.java
+++ b/src/test/java/org/apache/sling/testing/AbstractSlingClientGetUrlTest.java
@@ -130,7 +130,7 @@ public class AbstractSlingClientGetUrlTest {
         SlingClient c = new SlingClient(URI.create(serverUrl), "USER", "PWD");
         assertEquals("", URI.create(expectedUrl), c.getUrl(inputPath));
         assertEquals(URI.create(expectedUrl), c.getUrl(inputPath, null));
-        assertEquals(URI.create(expectedUrl + "?"), c.getUrl(inputPath, new ArrayList<NameValuePair>()));
+        assertEquals(URI.create(expectedUrl), c.getUrl(inputPath, new ArrayList<NameValuePair>()));
         assertEquals(URI.create(expectedUrl + "?" + STRING_TEST_PARAMETERS), c.getUrl(inputPath, TEST_PARAMETERS));
     }
 }


### PR DESCRIPTION
Annotations have been replaced based on https://linuxtut.com/replacement-of-annotation-threadsafe-notthreadsafe-removed-in-httpcore-4.4.5-4d580/ . 