### PR TITLE
SLING-11364 more precise exceptions 

### DIFF
--- a/src/main/java/org/apache/sling/testing/clients/AbstractSlingClient.java
+++ b/src/main/java/org/apache/sling/testing/clients/AbstractSlingClient.java
@@ -26,6 +26,8 @@ import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicHttpRequest;
 import org.apache.http.protocol.HttpContext;
+import org.apache.sling.testing.clients.exceptions.TestingIOException;
+import org.apache.sling.testing.clients.exceptions.TestingValidationException;
 import org.apache.sling.testing.clients.util.HttpUtils;
 import org.slf4j.LoggerFactory;
 
@@ -224,13 +226,13 @@ public class AbstractSlingClient implements HttpClient, Closeable {
      * @throws ClientException if client can't be instantiated
      */
     @SuppressWarnings("unchecked")
-    public <T extends AbstractSlingClient> T adaptTo(Class<T> clientClass) throws ClientException {
+    public <T extends AbstractSlingClient> T adaptTo(Class<T> clientClass) throws TestingValidationException {
         T client;
         try {
             Constructor cons = clientClass.getConstructor(CloseableHttpClient.class, SlingClientConfig.class);
             client = (T) cons.newInstance(this.http, this.config);
         } catch (Exception e) {
-            throw new ClientException("Could not initialize client: '" + clientClass.getCanonicalName() + "'.", e);
+            throw new TestingValidationException("Could not initialize client: '" + clientClass.getCanonicalName() + "'.", e);
         }
         return client;
     }
@@ -338,7 +340,7 @@ public class AbstractSlingClient implements HttpClient, Closeable {
 
             return response;
         } catch (IOException e) {
-            throw new ClientException("Could not execute http request", e, request, response);
+            throw new TestingIOException("Could not execute http request", e, request, response);
         }
     }
 
@@ -391,7 +393,7 @@ public class AbstractSlingClient implements HttpClient, Closeable {
 
             return response;
         } catch (IOException e) {
-            throw new ClientException("Could not execute http request", e);
+            throw new TestingIOException("Could not execute http request", e);
         }
     }
 

--- a/src/main/java/org/apache/sling/testing/clients/ClientException.java
+++ b/src/main/java/org/apache/sling/testing/clients/ClientException.java
@@ -19,7 +19,16 @@ package org.apache.sling.testing.clients;
 import org.apache.http.client.methods.HttpUriRequest;
 
 /**
- * An exception thrown when something went wrong with using the sling testing clients
+ * An exception thrown when something went wrong with using the sling testing clients.
+ * 
+ * This class will be turned into an abstract class eventually, so do use the specialized
+ * sub-classes instead:
+ * <ul>
+ *   <li>TestingIOException to indicate network and IO problems</li>
+ *   <li>TestingValidationException to indicate a mismatch between expecation and result</li>
+ * </ul>
+ * 
+ * 
  */
 public class ClientException extends Exception {
 
@@ -28,23 +37,28 @@ public class ClientException extends Exception {
     private HttpUriRequest request;
     private SlingHttpResponse response;
 
+    @Deprecated
     public ClientException(String message) {
         this(message, null);
     }
 
+    @Deprecated
     public ClientException(String message, Throwable throwable) {
         this(message, -1, throwable);
     }
 
+    @Deprecated
     public ClientException(String message, int httpStatusCode) {
         this(message, httpStatusCode, null);
     }
 
+    @Deprecated
     public ClientException(String message, int httpStatusCode, Throwable throwable) {
         super(message, throwable);
         this.httpStatusCode = httpStatusCode;
     }
 
+    @Deprecated
     public ClientException(String message, Throwable throwable, HttpUriRequest request, SlingHttpResponse response) {
         this(message, throwable);
         this.request = request;

--- a/src/main/java/org/apache/sling/testing/clients/ClientException.java
+++ b/src/main/java/org/apache/sling/testing/clients/ClientException.java
@@ -26,6 +26,7 @@ import org.apache.http.client.methods.HttpUriRequest;
  * <ul>
  *   <li>TestingIOException to indicate network and IO problems</li>
  *   <li>TestingValidationException to indicate a mismatch between expecation and result</li>
+ *   <li>TestingSetupException to indicate problems in the test setup (incorrect parameters etc)</li>
  * </ul>
  * 
  * 

--- a/src/main/java/org/apache/sling/testing/clients/SlingClient.java
+++ b/src/main/java/org/apache/sling/testing/clients/SlingClient.java
@@ -46,6 +46,7 @@ import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.cookie.BasicClientCookie;
+import org.apache.sling.testing.clients.exceptions.TestingValidationException;
 import org.apache.sling.testing.clients.interceptors.DelayRequestInterceptor;
 import org.apache.sling.testing.clients.interceptors.HttpRequestResponseInterceptor;
 import org.apache.sling.testing.clients.interceptors.TestDescriptionInterceptor;
@@ -249,7 +250,7 @@ public class SlingClient extends AbstractSlingClient {
      */
     @Deprecated
     public void waitUntilExists(final String path, final long waitMillis, int retryCount)
-            throws ClientException, InterruptedException {
+            throws TestingValidationException, InterruptedException {
         AbstractPoller poller =  new AbstractPoller(waitMillis, retryCount) {
             boolean found = false;
             public boolean call() {
@@ -269,7 +270,7 @@ public class SlingClient extends AbstractSlingClient {
 
         boolean found = poller.callUntilCondition();
         if (!found) {
-            throw new ClientException("path " + path + " does not exist after " + retryCount + " retries");
+            throw new TestingValidationException("path " + path + " does not exist after " + retryCount + " retries");
         }
     }
 

--- a/src/main/java/org/apache/sling/testing/clients/SlingClientConfig.java
+++ b/src/main/java/org/apache/sling/testing/clients/SlingClientConfig.java
@@ -30,8 +30,7 @@ import org.apache.http.impl.auth.BasicScheme;
 import org.apache.http.impl.client.BasicAuthCache;
 import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.sling.testing.clients.exceptions.TestingValidationException;
-
+import org.apache.sling.testing.clients.exceptions.TestingSetupException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
@@ -211,12 +210,12 @@ public class SlingClientConfig {
 
         public SlingClientConfig build() throws ClientException {
             if (!this.url.isAbsolute()) {
-                throw new TestingValidationException("Url must be absolute: " + url);
+                throw new TestingSetupException("Url must be absolute: " + url);
             }
 
             HttpHost targetHost = URIUtils.extractHost(this.url);
             if (targetHost == null) {
-                throw new TestingValidationException("Failed to extract hostname from url " + url);
+                throw new TestingSetupException("Failed to extract hostname from url " + url);
             }
 
             // Create default CredentialsProvider if not set

--- a/src/main/java/org/apache/sling/testing/clients/SlingClientConfig.java
+++ b/src/main/java/org/apache/sling/testing/clients/SlingClientConfig.java
@@ -30,6 +30,7 @@ import org.apache.http.impl.auth.BasicScheme;
 import org.apache.http.impl.client.BasicAuthCache;
 import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.sling.testing.clients.exceptions.TestingValidationException;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -210,12 +211,12 @@ public class SlingClientConfig {
 
         public SlingClientConfig build() throws ClientException {
             if (!this.url.isAbsolute()) {
-                throw new ClientException("Url must be absolute: " + url);
+                throw new TestingValidationException("Url must be absolute: " + url);
             }
 
             HttpHost targetHost = URIUtils.extractHost(this.url);
             if (targetHost == null) {
-                throw new ClientException("Failed to extract hostname from url " + url);
+                throw new TestingValidationException("Failed to extract hostname from url " + url);
             }
 
             // Create default CredentialsProvider if not set

--- a/src/main/java/org/apache/sling/testing/clients/SlingHttpResponse.java
+++ b/src/main/java/org/apache/sling/testing/clients/SlingHttpResponse.java
@@ -31,6 +31,7 @@ import org.apache.http.ProtocolVersion;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.util.EntityUtils;
+import org.apache.sling.testing.clients.exceptions.TestingValidationException;
 
 public class SlingHttpResponse implements CloseableHttpResponse {
 
@@ -79,9 +80,9 @@ public class SlingHttpResponse implements CloseableHttpResponse {
      * @param expected the expected http status
      * @throws ClientException if the response does not match the expected
      */
-    public void checkStatus(int expected) throws ClientException {
+    public void checkStatus(int expected) throws TestingValidationException {
         if (this.getStatusLine().getStatusCode() != expected) {
-            throw new ClientException(this + " has wrong response status ("
+            throw new TestingValidationException(this + " has wrong response status ("
                     + this.getStatusLine().getStatusCode() + "). Expected " + expected);
         }
     }
@@ -92,7 +93,7 @@ public class SlingHttpResponse implements CloseableHttpResponse {
      * @param expected the expected content type
      * @throws ClientException if the response content type does not match the expected
      */
-    public void checkContentType(String expected) throws ClientException {
+    public void checkContentType(String expected) throws TestingValidationException {
         // Remove whatever follows semicolon in content-type
         String contentType = this.getEntity().getContentType().getValue();
         if (contentType != null) {
@@ -101,7 +102,7 @@ public class SlingHttpResponse implements CloseableHttpResponse {
 
         // check for match
         if (!contentType.equals(expected)) {
-            throw new ClientException(this + " has wrong content type (" + contentType + "). Expected " + expected);
+            throw new TestingValidationException(this + " has wrong content type (" + contentType + "). Expected " + expected);
         }
     }
 
@@ -112,7 +113,7 @@ public class SlingHttpResponse implements CloseableHttpResponse {
      * @param regexp list of regular expressions
      * @throws ClientException if the response content does not match one of the regexp
      */
-    public void checkContentRegexp(String... regexp) throws ClientException {
+    public void checkContentRegexp(String... regexp) throws TestingValidationException {
         for(String expr : regexp) {
             final Pattern p = Pattern.compile(".*" + expr + ".*");
             boolean matched = false;
@@ -127,7 +128,7 @@ public class SlingHttpResponse implements CloseableHttpResponse {
             }
 
             if (!matched) {
-                throw new ClientException("Pattern " + p + " didn't match any line in content. Content is: \n\n" + getContent());
+                throw new TestingValidationException("Pattern " + p + " didn't match any line in content. Content is: \n\n" + getContent());
             }
         }
     }
@@ -138,10 +139,10 @@ public class SlingHttpResponse implements CloseableHttpResponse {
      * @param expected list of expected strings
      * @throws ClientException @throws ClientException if the response content does not match one of the strings
      */
-    public void checkContentContains(String... expected) throws ClientException {
+    public void checkContentContains(String... expected) throws TestingValidationException {
         for (String s : expected) {
             if (!this.getContent().contains(s)) {
-                throw new ClientException("Content does not contain string " + s + ". Content is: \n\n" + getContent());
+                throw new TestingValidationException("Content does not contain string " + s + ". Content is: \n\n" + getContent());
             }
         }
     }

--- a/src/main/java/org/apache/sling/testing/clients/email/SlingEmailClient.java
+++ b/src/main/java/org/apache/sling/testing/clients/email/SlingEmailClient.java
@@ -27,6 +27,7 @@ import org.apache.sling.testing.clients.ClientException;
 import org.apache.sling.testing.clients.SlingClient;
 import org.apache.sling.testing.clients.SlingClientConfig;
 import org.apache.sling.testing.clients.SlingHttpResponse;
+import org.apache.sling.testing.clients.exceptions.TestingIOException;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -74,7 +75,7 @@ public final class SlingEmailClient extends SlingClient {
             JsonNode configNode = mapper.readTree(mockEmailConfig.getContent());
             return configNode.get("bindPort").intValue();
         } catch (IOException e) {
-            throw new ClientException("Failed retrieving configuration", e);
+            throw new TestingIOException("Failed retrieving configuration", e);
         }
     }
 
@@ -104,7 +105,7 @@ public final class SlingEmailClient extends SlingClient {
                 emails.add(msg);
             }
         } catch (IOException e) {
-            throw new ClientException("Failed retrieving email messages", e);
+            throw new TestingIOException("Failed retrieving email messages", e);
         }
 
 

--- a/src/main/java/org/apache/sling/testing/clients/exceptions/TestingIOException.java
+++ b/src/main/java/org/apache/sling/testing/clients/exceptions/TestingIOException.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.testing.clients.exceptions;
+
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.sling.testing.clients.ClientException;
+import org.apache.sling.testing.clients.SlingHttpResponse;
+
+public class TestingIOException extends ClientException {
+
+	public TestingIOException(String message) {
+		super(message);
+	}
+	
+    public TestingIOException(String message, Throwable throwable) {
+    	super(message, throwable);
+    }
+
+    public TestingIOException(String message, int httpStatusCode) {
+        super(message, httpStatusCode);
+    }
+
+    public TestingIOException(String message, int httpStatusCode, Throwable throwable) {
+        super(message, httpStatusCode, throwable);
+    }
+
+    public TestingIOException(String message, Throwable throwable, HttpUriRequest request, SlingHttpResponse response) {
+        super(message, throwable, request, response);
+    }
+}

--- a/src/main/java/org/apache/sling/testing/clients/exceptions/TestingIOException.java
+++ b/src/main/java/org/apache/sling/testing/clients/exceptions/TestingIOException.java
@@ -22,6 +22,10 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.sling.testing.clients.ClientException;
 import org.apache.sling.testing.clients.SlingHttpResponse;
 
+/**
+ * Use this exception to indicate any problems with networking (typically manifested as 
+ * IOException).
+ */
 public class TestingIOException extends ClientException {
 
 	public TestingIOException(String message) {

--- a/src/main/java/org/apache/sling/testing/clients/exceptions/TestingSetupException.java
+++ b/src/main/java/org/apache/sling/testing/clients/exceptions/TestingSetupException.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.testing.clients.exceptions;
+
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.sling.testing.clients.ClientException;
+import org.apache.sling.testing.clients.SlingHttpResponse;
+
+public class TestingSetupException extends ClientException {
+
+	public TestingSetupException(String message) {
+		super(message);
+	}
+	
+    public TestingSetupException(String message, Throwable throwable) {
+    	super(message, throwable);
+    }
+
+    public TestingSetupException(String message, int httpStatusCode) {
+        super(message, httpStatusCode);
+    }
+
+    public TestingSetupException(String message, int httpStatusCode, Throwable throwable) {
+        super(message, httpStatusCode, throwable);
+    }
+
+    public TestingSetupException(String message, Throwable throwable, HttpUriRequest request, SlingHttpResponse response) {
+        super(message, throwable, request, response);
+    }
+}

--- a/src/main/java/org/apache/sling/testing/clients/exceptions/TestingSetupException.java
+++ b/src/main/java/org/apache/sling/testing/clients/exceptions/TestingSetupException.java
@@ -22,6 +22,10 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.sling.testing.clients.ClientException;
 import org.apache.sling.testing.clients.SlingHttpResponse;
 
+/**
+ * Use this exception to signal problems in the test setup, e.g. incorrect or missing
+ * parameters.
+ */
 public class TestingSetupException extends ClientException {
 
 	public TestingSetupException(String message) {

--- a/src/main/java/org/apache/sling/testing/clients/exceptions/TestingValidationException.java
+++ b/src/main/java/org/apache/sling/testing/clients/exceptions/TestingValidationException.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.testing.clients.exceptions;
+
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.sling.testing.clients.ClientException;
+import org.apache.sling.testing.clients.SlingHttpResponse;
+
+public class TestingValidationException extends ClientException {
+
+	public TestingValidationException(String message) {
+		super(message);
+	}
+	
+    public TestingValidationException(String message, Throwable throwable) {
+    	super(message, throwable);
+    }
+
+    public TestingValidationException(String message, int httpStatusCode) {
+        super(message, httpStatusCode);
+    }
+
+    public TestingValidationException(String message, int httpStatusCode, Throwable throwable) {
+        super(message, httpStatusCode, throwable);
+    }
+
+    public TestingValidationException(String message, Throwable throwable, HttpUriRequest request, SlingHttpResponse response) {
+        super(message, throwable, request, response);
+    }
+}

--- a/src/main/java/org/apache/sling/testing/clients/exceptions/TestingValidationException.java
+++ b/src/main/java/org/apache/sling/testing/clients/exceptions/TestingValidationException.java
@@ -22,6 +22,11 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.sling.testing.clients.ClientException;
 import org.apache.sling.testing.clients.SlingHttpResponse;
 
+/**
+ * Use this exception to indicate any mismatch between expectations and the actual
+ * test result. This exception typically indicates "real" test failures.
+ *
+ */
 public class TestingValidationException extends ClientException {
 
 	public TestingValidationException(String message) {

--- a/src/main/java/org/apache/sling/testing/clients/exceptions/package-info.java
+++ b/src/main/java/org/apache/sling/testing/clients/exceptions/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+@Version("1.0.0")
+package org.apache.sling.testing.clients.exceptions;
+
+import org.osgi.annotation.versioning.Version;

--- a/src/main/java/org/apache/sling/testing/clients/indexing/IndexingClient.java
+++ b/src/main/java/org/apache/sling/testing/clients/indexing/IndexingClient.java
@@ -23,6 +23,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.sling.testing.clients.ClientException;
 import org.apache.sling.testing.clients.SlingClient;
 import org.apache.sling.testing.clients.SlingClientConfig;
+import org.apache.sling.testing.clients.exceptions.TestingValidationException;
 import org.apache.sling.testing.clients.osgi.OsgiConsoleClient;
 import org.apache.sling.testing.clients.query.QueryClient;
 import org.apache.sling.testing.clients.util.poller.Polling;
@@ -190,7 +191,7 @@ public class IndexingClient extends SlingClient {
      * Else, retrieves configured lanes on the instance
      *
      * @return list of lane names
-     * @throws ClientException if the request fails
+     * @throws ClientException 
      */
     public List<String> getLaneNames() throws ClientException {
         List<String> configuredLanes = getConfiguredLaneNames();
@@ -202,7 +203,7 @@ public class IndexingClient extends SlingClient {
         if (configs instanceof String[]) {
             return Stream.of((String[]) configs).map(e -> e.split(":")[0]).collect(Collectors.toList());
         } else {
-            throw new ClientException("Cannot retrieve config from AsyncIndexerService, asyncConfigs is not a String[]");
+            throw new TestingValidationException("Cannot retrieve config from AsyncIndexerService, asyncConfigs is not a String[]");
         }
     }
 

--- a/src/main/java/org/apache/sling/testing/clients/osgi/BundleInfo.java
+++ b/src/main/java/org/apache/sling/testing/clients/osgi/BundleInfo.java
@@ -18,7 +18,7 @@
 package org.apache.sling.testing.clients.osgi;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.apache.sling.testing.clients.ClientException;
+import org.apache.sling.testing.clients.exceptions.TestingValidationException;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -28,15 +28,15 @@ public class BundleInfo {
 
     private JsonNode bundle;
 
-    public BundleInfo(JsonNode root) throws ClientException {
+    public BundleInfo(JsonNode root) throws TestingValidationException {
         if (root.get("id") != null) {
             if (root.get("id") == null) {
-                throw new ClientException("No Bundle Info returned");
+                throw new TestingValidationException("No Bundle Info returned");
             }
             bundle = root;
         } else {
             if (root.get("data") == null && root.get("data").size() < 1) {
-                throw new ClientException("No Bundle Info returned");
+                throw new TestingValidationException("No Bundle Info returned");
             }
             bundle = root.get("data").get(0);
         }

--- a/src/main/java/org/apache/sling/testing/clients/osgi/BundlesInfo.java
+++ b/src/main/java/org/apache/sling/testing/clients/osgi/BundlesInfo.java
@@ -19,6 +19,7 @@ package org.apache.sling.testing.clients.osgi;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.sling.testing.clients.ClientException;
+import org.apache.sling.testing.clients.exceptions.TestingValidationException;
 
 import java.util.Iterator;
 
@@ -37,13 +38,13 @@ public class BundlesInfo {
      * @param root the root JSON node of the bundles info.
      * @throws ClientException if the json does not contain the proper info
      */
-    public BundlesInfo(JsonNode root) throws ClientException {
+    public BundlesInfo(JsonNode root) throws TestingValidationException {
         this.root = root;
         // some simple sanity checks
         if (root.get("s") == null)
-            throw new ClientException("No Status Info returned!");
+            throw new TestingValidationException("No Status Info returned!");
         if (root.get("s").size() != 5)
-            throw new ClientException("Wrong number of status numbers listed!");
+            throw new TestingValidationException("Wrong number of status numbers listed!");
         status = root.get("s");
     }
 
@@ -51,9 +52,9 @@ public class BundlesInfo {
      * @return the status message of the bundle context
      * @throws ClientException if the request cannot be completed
      */
-    public String getStatusMessage() throws ClientException {
+    public String getStatusMessage() throws TestingValidationException {
         if (root.get("status") == null)
-            throw new ClientException("No Status message returned!");
+            throw new TestingValidationException("No Status message returned!");
         return root.get("status").asText();
     }
 

--- a/src/main/java/org/apache/sling/testing/clients/osgi/BundlesInstaller.java
+++ b/src/main/java/org/apache/sling/testing/clients/osgi/BundlesInstaller.java
@@ -17,6 +17,7 @@
 package org.apache.sling.testing.clients.osgi;
 
 import org.apache.sling.testing.clients.ClientException;
+import org.apache.sling.testing.clients.exceptions.TestingValidationException;
 import org.apache.sling.testing.clients.util.poller.Polling;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,7 +60,7 @@ public class BundlesInstaller {
             return false;
         } catch (IOException e) {
             log.debug("Failed to retrieve bundle symbolic name from file. ", e);
-            throw new ClientException("Failed to retrieve bundle symbolic name from file. ", e);
+            throw new TestingValidationException("Failed to retrieve bundle symbolic name from file. ", e);
         }
     }
 

--- a/src/main/java/org/apache/sling/testing/clients/osgi/ComponentInfo.java
+++ b/src/main/java/org/apache/sling/testing/clients/osgi/ComponentInfo.java
@@ -19,20 +19,21 @@ package org.apache.sling.testing.clients.osgi;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.sling.testing.clients.ClientException;
+import org.apache.sling.testing.clients.exceptions.TestingValidationException;
 
 public class ComponentInfo {
 
     private JsonNode component;
 
-    public ComponentInfo(JsonNode root) throws ClientException {
+    public ComponentInfo(JsonNode root) throws TestingValidationException {
         if (root.get("id") != null) {
             if (root.get("id") == null) {
-                throw new ClientException("No Component Info returned");
+                throw new TestingValidationException("No Component Info returned");
             }
             component = root;
         } else {
             if (root.get("data") == null && root.get("data").size() < 1) {
-                throw new ClientException("No Component Info returned");
+                throw new TestingValidationException("No Component Info returned");
             }
             component = root.get("data").get(0);
         }

--- a/src/main/java/org/apache/sling/testing/clients/osgi/ComponentsInfo.java
+++ b/src/main/java/org/apache/sling/testing/clients/osgi/ComponentsInfo.java
@@ -19,6 +19,7 @@ package org.apache.sling.testing.clients.osgi;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.sling.testing.clients.ClientException;
+import org.apache.sling.testing.clients.exceptions.TestingValidationException;
 
 import java.util.Iterator;
 
@@ -36,7 +37,7 @@ public class ComponentsInfo {
      * @param rootNode the root JSON node of the components info.
      * @throws ClientException if the info cannot be retrieved
      */
-    public ComponentsInfo(JsonNode rootNode) throws ClientException {
+    public ComponentsInfo(JsonNode rootNode) {
         this.root = rootNode;
     }
 
@@ -44,9 +45,9 @@ public class ComponentsInfo {
      * @return the number of installed components
      * @throws ClientException if the info cannot be retrieved
      */
-    public int getNumberOfInstalledComponents() throws ClientException {
+    public int getNumberOfInstalledComponents() throws TestingValidationException {
         if (root.get("status") == null)
-            throw new ClientException("Number of installed Components not defined!");
+            throw new TestingValidationException("Number of installed Components not defined!");
         return Integer.parseInt(root.get("status").asText());
     }
 
@@ -55,7 +56,7 @@ public class ComponentsInfo {
      * @return the ComponentInfo for a component with the identifier {@code id}
      * @throws ClientException if the info cannot be retrieved
      */
-    public ComponentInfo forId(String id) throws ClientException {
+    public ComponentInfo forId(String id) throws TestingValidationException {
         JsonNode component = findBy("id", id);
         return (component != null) ? new ComponentInfo(component) : null;
     }
@@ -65,7 +66,7 @@ public class ComponentsInfo {
      * @return the ComponentInfo for a component with the name {@code name}
      * @throws ClientException if the info cannot be retrieved
      */
-    public ComponentInfo forName(String name) throws ClientException {
+    public ComponentInfo forName(String name) throws TestingValidationException {
         JsonNode component = findBy("name", name);
         return (component != null) ? new ComponentInfo(component) : null;
     }
@@ -75,7 +76,7 @@ public class ComponentsInfo {
      * @return the ComponentInfo for a component with the pid {@code pid}
      * @throws ClientException if the info cannot be retrieved
      */
-    public ComponentInfo forPid(String pid) throws ClientException {
+    public ComponentInfo forPid(String pid) throws TestingValidationException {
         JsonNode component = findBy("pid", pid);
         return (component != null) ? new ComponentInfo(component) : null;
     }

--- a/src/main/java/org/apache/sling/testing/clients/osgi/OsgiConsoleClient.java
+++ b/src/main/java/org/apache/sling/testing/clients/osgi/OsgiConsoleClient.java
@@ -25,6 +25,8 @@ import org.apache.sling.testing.clients.ClientException;
 import org.apache.sling.testing.clients.SlingClient;
 import org.apache.sling.testing.clients.SlingClientConfig;
 import org.apache.sling.testing.clients.SlingHttpResponse;
+import org.apache.sling.testing.clients.exceptions.TestingIOException;
+import org.apache.sling.testing.clients.exceptions.TestingValidationException;
 import org.apache.sling.testing.clients.util.FormEntityBuilder;
 import org.apache.sling.testing.clients.util.HttpUtils;
 import org.apache.sling.testing.clients.util.JsonUtils;
@@ -388,12 +390,12 @@ public class OsgiConsoleClient extends SlingClient {
      */
     @Deprecated
     public Map<String, Object> getConfigurationWithWait(long waitCount, String pid, int... expectedStatus)
-            throws ClientException, InterruptedException {
+            throws TestingValidationException, InterruptedException {
         ConfigurationPoller poller = new ConfigurationPoller(pid, expectedStatus);
         try {
             poller.poll(500L * waitCount, 500);
         } catch (TimeoutException e) {
-            throw new ClientException("Cannot retrieve configuration.", e);
+            throw new TestingValidationException("Cannot retrieve configuration.", e);
         }
         return poller.getConfig();
     }
@@ -626,7 +628,7 @@ public class OsgiConsoleClient extends SlingClient {
         try {
             return this.checkBundleInstalled(OsgiConsoleClient.getBundleSymbolicName(f), waitTime, retries);
         } catch (IOException e) {
-            throw new ClientException("Cannot get bundle symbolic name", e);
+            throw new TestingIOException("Cannot get bundle symbolic name", e);
         }
     }
 
@@ -648,7 +650,7 @@ public class OsgiConsoleClient extends SlingClient {
         try {
             waitBundleInstalled(getBundleSymbolicName(f), timeout, delay);
         } catch (IOException e) {
-            throw new ClientException("Cannot get bundle symbolic name", e);
+            throw new TestingIOException("Cannot get bundle symbolic name", e);
         }
     }
 
@@ -724,7 +726,7 @@ public class OsgiConsoleClient extends SlingClient {
         final JsonNode idNode = bundle.get(JSON_KEY_ID);
 
         if (idNode == null) {
-            throw new ClientException("Cannot get id from bundle json");
+            throw new TestingValidationException("Cannot get id from bundle json");
         }
 
         return idNode.longValue();
@@ -741,7 +743,7 @@ public class OsgiConsoleClient extends SlingClient {
         final JsonNode versionNode = bundle.get(JSON_KEY_VERSION);
 
         if (versionNode == null) {
-            throw new ClientException("Cannot get version from bundle json");
+            throw new TestingValidationException("Cannot get version from bundle json");
         }
 
         return versionNode.textValue();
@@ -758,7 +760,7 @@ public class OsgiConsoleClient extends SlingClient {
         final JsonNode stateNode = bundle.get(JSON_KEY_STATE);
 
         if (stateNode == null) {
-            throw new ClientException("Cannot get state from bundle json");
+            throw new TestingValidationException("Cannot get state from bundle json");
         }
 
         return stateNode.textValue();
@@ -871,17 +873,17 @@ public class OsgiConsoleClient extends SlingClient {
         final JsonNode root = JsonUtils.getJsonNodeFromString(content);
 
         if (root.get(JSON_KEY_DATA) == null) {
-            throw new ClientException(path + " does not provide '" + JSON_KEY_DATA + "' element, JSON content=" + content);
+            throw new TestingValidationException(path + " does not provide '" + JSON_KEY_DATA + "' element, JSON content=" + content);
         }
 
         Iterator<JsonNode> data = root.get(JSON_KEY_DATA).elements();
         if (!data.hasNext()) {
-            throw new ClientException(path + "." + JSON_KEY_DATA + " is empty, JSON content=" + content);
+            throw new TestingValidationException(path + "." + JSON_KEY_DATA + " is empty, JSON content=" + content);
         }
 
         final JsonNode bundle = data.next();
         if (bundle.get(JSON_KEY_STATE) == null) {
-            throw new ClientException(path + ".data[0].state missing, JSON content=" + content);
+            throw new TestingValidationException(path + ".data[0].state missing, JSON content=" + content);
         }
 
         return bundle;

--- a/src/main/java/org/apache/sling/testing/clients/osgi/ServiceInfo.java
+++ b/src/main/java/org/apache/sling/testing/clients/osgi/ServiceInfo.java
@@ -19,6 +19,7 @@ package org.apache.sling.testing.clients.osgi;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.sling.testing.clients.ClientException;
+import org.apache.sling.testing.clients.exceptions.TestingValidationException;
 
 import java.util.List;
 
@@ -26,12 +27,12 @@ public class ServiceInfo {
 
     private JsonNode service;
 
-    public ServiceInfo(JsonNode root) throws ClientException {
+    public ServiceInfo(JsonNode root) throws TestingValidationException {
         if(root.get("id") != null) {
             service = root;
         } else {
             if(root.get("data") == null && root.get("data").size() < 1) {
-                throw new ClientException("No service info returned");
+                throw new TestingValidationException("No service info returned");
             }
             service = root.get("data").get(0);
         }

--- a/src/main/java/org/apache/sling/testing/clients/osgi/ServicesInfo.java
+++ b/src/main/java/org/apache/sling/testing/clients/osgi/ServicesInfo.java
@@ -18,7 +18,7 @@
 package org.apache.sling.testing.clients.osgi;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.apache.sling.testing.clients.ClientException;
+import org.apache.sling.testing.clients.exceptions.TestingValidationException;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -40,13 +40,13 @@ public class ServicesInfo {
      * @param root the root JSON node of the bundles info.
      * @throws ClientException if the json does not contain the proper info
      */
-    public ServicesInfo(JsonNode root) throws ClientException {
+    public ServicesInfo(JsonNode root) throws TestingValidationException {
         this.root = root;
         // some simple sanity checks
         if (root.get("status") == null)
-            throw new ClientException("No Status returned!");
+            throw new TestingValidationException("No Status returned!");
         if (root.get("serviceCount") == null)
-            throw new ClientException("No serviceCount returned!");
+            throw new TestingValidationException("No serviceCount returned!");
     }
 
     /**
@@ -63,7 +63,7 @@ public class ServicesInfo {
      * @return the BundleInfo
      * @throws ClientException if the info could not be retrieved
      */
-    public ServiceInfo forId(String id) throws ClientException {
+    public ServiceInfo forId(String id) throws TestingValidationException {
         JsonNode serviceInfo = findBy("id", id);
         return (serviceInfo != null) ? new ServiceInfo(serviceInfo) : null;
     }
@@ -75,7 +75,7 @@ public class ServicesInfo {
      * @return a Collection of {@link ServiceInfo}s of all services with the given type. Might be empty, never {@code null}
      * @throws ClientException if the info cannot be retrieved
      */
-    public Collection<ServiceInfo> forType(String type) throws ClientException {
+    public Collection<ServiceInfo> forType(String type)throws TestingValidationException {
         List<ServiceInfo> results = new LinkedList<>();
         List<JsonNode> serviceInfoNodes = findAllContainingValueInArray("types", type);
         for (JsonNode serviceInfoNode : serviceInfoNodes) {

--- a/src/main/java/org/apache/sling/testing/clients/query/QueryClient.java
+++ b/src/main/java/org/apache/sling/testing/clients/query/QueryClient.java
@@ -23,6 +23,8 @@ import org.apache.sling.testing.clients.ClientException;
 import org.apache.sling.testing.clients.SlingClient;
 import org.apache.sling.testing.clients.SlingClientConfig;
 import org.apache.sling.testing.clients.SlingHttpResponse;
+import org.apache.sling.testing.clients.exceptions.TestingIOException;
+import org.apache.sling.testing.clients.exceptions.TestingValidationException;
 import org.apache.sling.testing.clients.osgi.OsgiConsoleClient;
 import org.apache.sling.testing.clients.query.servlet.QueryServlet;
 import org.apache.sling.testing.clients.util.JsonUtils;
@@ -203,9 +205,9 @@ public class QueryClient extends SlingClient {
 
             LOG.info("query servlet installed at {}", getUrl(QueryServlet.SERVLET_PATH));
         } catch (IOException e) {
-            throw new ClientException("Failed to create the query servlet bundle", e);
+            throw new TestingIOException("Failed to create the query servlet bundle", e);
         } catch (TimeoutException e) {
-            throw new ClientException("The query servlet bundle did not successfully start", e);
+            throw new TestingValidationException("The query servlet bundle did not successfully start", e);
         }
 
         return this;

--- a/src/main/java/org/apache/sling/testing/clients/util/HttpUtils.java
+++ b/src/main/java/org/apache/sling/testing/clients/util/HttpUtils.java
@@ -20,7 +20,7 @@ import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.sling.testing.clients.ClientException;
 import org.apache.sling.testing.clients.SlingHttpResponse;
-
+import org.apache.sling.testing.clients.exceptions.TestingValidationException;
 
 import java.net.URI;
 
@@ -35,7 +35,7 @@ public class HttpUtils {
      * @param expectedStatus List of acceptable HTTP Statuses
      * @throws ClientException if status is not expected
      */
-    public static void verifyHttpStatus(SlingHttpResponse response, int... expectedStatus) throws ClientException {
+    public static void verifyHttpStatus(SlingHttpResponse response, int... expectedStatus) throws TestingValidationException {
         if (!checkStatus(response, expectedStatus)) {
             throwError(response, buildDefaultErrorMessage(response), expectedStatus);
         }
@@ -50,14 +50,13 @@ public class HttpUtils {
      * @throws ClientException if status is not expected
      */
     public static void verifyHttpStatus(HttpResponse response, String errorMessage, int... expectedStatus)
-            throws ClientException {
+            throws TestingValidationException {
         if (!checkStatus(response, expectedStatus)) {
             throwError(response, errorMessage, expectedStatus);
         }
     }
 
-    private static boolean checkStatus(HttpResponse response, int... expectedStatus)
-            throws ClientException {
+    private static boolean checkStatus(HttpResponse response, int... expectedStatus) {
 
         // if no HttpResponse was given
         if (response == null) {
@@ -83,7 +82,7 @@ public class HttpUtils {
     }
 
     private static boolean throwError(HttpResponse response, String errorMessage, int... expectedStatus)
-            throws ClientException {
+            throws TestingValidationException {
         // build error message
         String errorMsg = "Expected HTTP Status: ";
         for (int expected : expectedStatus) {
@@ -99,7 +98,7 @@ public class HttpUtils {
         }
 
         // throw the exception
-        throw new ClientException(errorMsg, givenStatus);
+        throw new TestingValidationException(errorMsg, givenStatus);
     }
 
 
@@ -133,7 +132,7 @@ public class HttpUtils {
      * @return The HTTP Status of the response
      * @throws ClientException never (kept for uniformity)
      */
-    public static int getHttpStatus(HttpResponse response) throws ClientException {
+    public static int getHttpStatus(HttpResponse response) {
         return response.getStatusLine().getStatusCode();
     }
 
@@ -144,8 +143,8 @@ public class HttpUtils {
      * @return the location path
      * @throws ClientException never (kept for uniformity)
      */
-    public static String getLocationHeader(HttpResponse response) throws ClientException {
-        if (response == null) throw new ClientException("Response must not be null!");
+    public static String getLocationHeader(HttpResponse response) throws TestingValidationException {
+        if (response == null) throw new TestingValidationException("Response must not be null!");
 
         String locationPath = null;
         Header locationHeader = response.getFirstHeader("Location");
@@ -156,7 +155,7 @@ public class HttpUtils {
         }
 
         if (locationPath == null) {
-            throw new ClientException("not able to determine location path");
+            throw new TestingValidationException("not able to determine location path");
         }
         return locationPath;
     }

--- a/src/main/java/org/apache/sling/testing/clients/util/InputStreamBodyWithLength.java
+++ b/src/main/java/org/apache/sling/testing/clients/util/InputStreamBodyWithLength.java
@@ -19,6 +19,7 @@ package org.apache.sling.testing.clients.util;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.mime.content.InputStreamBody;
 import org.apache.sling.testing.clients.ClientException;
+import org.apache.sling.testing.clients.exceptions.TestingIOException;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -47,7 +48,7 @@ public class InputStreamBodyWithLength extends InputStreamBody {
      * @param resourcePath path to the file
      * @return the size of the resource
      */
-    private static long getResourceStreamLength(String resourcePath) throws ClientException {
+    private static long getResourceStreamLength(String resourcePath) throws TestingIOException {
         int streamLength = 0;
         InputStream stream = ResourceUtil.getResourceAsStream(resourcePath);
         try {
@@ -56,12 +57,12 @@ public class InputStreamBodyWithLength extends InputStreamBody {
                 stream.skip(avail);
             }
         } catch (IOException e) {
-            throw new ClientException("Could not read " + resourcePath + "!", e);
+            throw new TestingIOException("Could not read " + resourcePath + "!", e);
         } finally {
             try {
                 stream.close();
             } catch (IOException e) {
-                throw new ClientException("Could not close Inputstream for " + resourcePath + "!", e);
+                throw new TestingIOException("Could not close Inputstream for " + resourcePath + "!", e);
             }
         }
         return streamLength;

--- a/src/main/java/org/apache/sling/testing/clients/util/JsonUtils.java
+++ b/src/main/java/org/apache/sling/testing/clients/util/JsonUtils.java
@@ -19,6 +19,7 @@ package org.apache.sling.testing.clients.util;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.sling.testing.clients.ClientException;
+import org.apache.sling.testing.clients.exceptions.TestingIOException;
 
 import java.io.IOException;
 
@@ -30,12 +31,12 @@ public class JsonUtils {
      * @return A {@link JsonNode} that is the root node of the JSON structure.
      * @throws ClientException if error occurs while reading json string
      */
-    public static JsonNode getJsonNodeFromString(String jsonString) throws ClientException {
+    public static JsonNode getJsonNodeFromString(String jsonString) throws TestingIOException {
         try {
             ObjectMapper mapper = new ObjectMapper();
             return mapper.readTree(jsonString);
         } catch (IOException e) {
-            throw new ClientException("Could not read json node.", e);
+            throw new TestingIOException("Could not read json node.", e);
         }
     }
 }


### PR DESCRIPTION
use more specialized exceptions than the generic ``ClientException``. With this it should be possible that the TestDriver can give more accurate indications about the type of error:
* error in the test setup
* I/O issues
* or "real" test failures