### PR TITLE
SLING-11748 - Improve logging output of HTTP retries in testing clients

### DIFF
--- a/src/main/java/org/apache/sling/testing/clients/util/ServerErrorRetryStrategy.java
+++ b/src/main/java/org/apache/sling/testing/clients/util/ServerErrorRetryStrategy.java
@@ -92,7 +92,14 @@ public class ServerErrorRetryStrategy implements ServiceUnavailableRetryStrategy
         HttpClientContext clientContext = HttpClientContext.adapt(context);
         HttpRequestWrapper wrapper = clientContext.getAttribute(HttpClientContext.HTTP_REQUEST, HttpRequestWrapper.class);
         if (wrapper != null) {
-            details = wrapper.toString();
+            // Build a request detail string like following example:
+            // GET /test/internalerror/resource HTTP/1.1 [Host: 127.0.0.1:35049, Connection: Keep-Alive, User-Agent: Java, Accept-Encoding: gzip,deflate, Authorization: Basic dXNlcjpwYXNz]
+            final StringBuilder sb = new StringBuilder(wrapper.getRequestLine().toString());
+            sb.append(" [");
+            Arrays.stream(wrapper.getAllHeaders()).forEach(header -> sb.append(header.getName()).append(": ").append(header.getValue()).append(", "));
+            sb.append("]");
+            details = sb.toString();
+
         }
         return details;
     }
@@ -103,6 +110,8 @@ public class ServerErrorRetryStrategy implements ServiceUnavailableRetryStrategy
     private String getResponseDetails(HttpResponse response) {
         String details = "Not available";
         if (response != null) {
+            // Build a response string like following example:
+            // HTTP/1.1 500 Internal Server Error [Date: Thu, 12 Jan 2023 08:32:42 GMT, Server: TEST/1.1, Content-Length: 8, Content-Type: text/plain; charset=ISO-8859-1, Connection: Keep-Alive, ]
             final StringBuilder sb = new StringBuilder(response.getStatusLine().toString());
             sb.append(" [");
             Arrays.stream(response.getAllHeaders()).forEach(h -> sb.append(h.getName()).append(": ").append(h.getValue()).append(", "));

--- a/src/main/java/org/apache/sling/testing/clients/util/ServerErrorRetryStrategy.java
+++ b/src/main/java/org/apache/sling/testing/clients/util/ServerErrorRetryStrategy.java
@@ -39,6 +39,7 @@ import static org.apache.sling.testing.Constants.EXPECTED_STATUS;
 public class ServerErrorRetryStrategy implements ServiceUnavailableRetryStrategy {
 
     private static final Logger LOG = LoggerFactory.getLogger(ServerErrorRetryStrategy.class);
+    private Collection<Integer> httpRetriesErrorCodes;
 
     public ServerErrorRetryStrategy() {
         super();
@@ -47,11 +48,13 @@ public class ServerErrorRetryStrategy implements ServiceUnavailableRetryStrategy
     @Override
     public boolean retryRequest(final HttpResponse response, final int executionCount, final HttpContext context) {
         int[] expectedStatus = (int[]) context.getAttribute(EXPECTED_STATUS);
-        boolean needsRetry = executionCount <= SystemPropertiesConfig.getHttpRetries() && responseRetryCondition(response, expectedStatus);
+        boolean needsRetry = executionCount <= SystemPropertiesConfig.getHttpRetries() &&
+                responseRetryCondition(response, expectedStatus);
 
         if (SystemPropertiesConfig.isHttpLogRetries() && needsRetry && LOG.isWarnEnabled()) {
             LOG.warn("Request retry condition met: [count={}/{}], [expected-codes={}], [retry-codes={}]",
-                    executionCount, SystemPropertiesConfig.getHttpRetries(), expectedStatus, SystemPropertiesConfig.getHttpRetriesErrorCodes());
+                    executionCount, SystemPropertiesConfig.getHttpRetries(), expectedStatus,
+                    httpRetriesErrorCodes);
             LOG.warn("Request: {}", getRequestDetails(context));
             LOG.warn("Response: {}", getResponseDetails(response));
             try {
@@ -93,10 +96,12 @@ public class ServerErrorRetryStrategy implements ServiceUnavailableRetryStrategy
         HttpRequestWrapper wrapper = clientContext.getAttribute(HttpClientContext.HTTP_REQUEST, HttpRequestWrapper.class);
         if (wrapper != null) {
             // Build a request detail string like following example:
-            // GET /test/internalerror/resource HTTP/1.1 [Host: 127.0.0.1:35049, Connection: Keep-Alive, User-Agent: Java, Accept-Encoding: gzip,deflate, Authorization: Basic dXNlcjpwYXNz]
+            // GET /test/internalerror/resource HTTP/1.1 [Host: 127.0.0.1:35049, Connection: Keep-Alive, User-Agent: Java,
+            //   Accept-Encoding: gzip,deflate, Authorization: Basic dXNlcjpwYXNz]
             final StringBuilder sb = new StringBuilder(wrapper.getRequestLine().toString());
             sb.append(" [");
-            Arrays.stream(wrapper.getAllHeaders()).forEach(header -> sb.append(header.getName()).append(": ").append(header.getValue()).append(", "));
+            Arrays.stream(wrapper.getAllHeaders()).forEach(header ->
+                    sb.append(header.getName()).append(": ").append(header.getValue()).append(", "));
             sb.append("]");
             details = sb.toString();
 
@@ -111,10 +116,12 @@ public class ServerErrorRetryStrategy implements ServiceUnavailableRetryStrategy
         String details = "Not available";
         if (response != null) {
             // Build a response string like following example:
-            // HTTP/1.1 500 Internal Server Error [Date: Thu, 12 Jan 2023 08:32:42 GMT, Server: TEST/1.1, Content-Length: 8, Content-Type: text/plain; charset=ISO-8859-1, Connection: Keep-Alive, ]
+            // HTTP/1.1 500 Internal Server Error [Date: Thu, 12 Jan 2023 08:32:42 GMT, Server: TEST/1.1, 
+            //   Content-Length: 8, Content-Type: text/plain; charset=ISO-8859-1, Connection: Keep-Alive, ]
             final StringBuilder sb = new StringBuilder(response.getStatusLine().toString());
             sb.append(" [");
-            Arrays.stream(response.getAllHeaders()).forEach(h -> sb.append(h.getName()).append(": ").append(h.getValue()).append(", "));
+            Arrays.stream(response.getAllHeaders()).forEach(h ->
+                    sb.append(h.getName()).append(": ").append(h.getValue()).append(", "));
             sb.append("]");
             details = sb.toString();
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SLING-11748

Proposal for improving the HTTP retry log output in the testing clients.

Current Output (from unit test):
```
Request retry needed due to service unavailable response
Response headers contained:
Header Date:Wed, 11 Jan 2023 08:36:43 GMT
Header Server:TEST/1.1
Header Content-Length:8
Header Content-Type:text/plain; charset=ISO-8859-1
Header Connection:Keep-Alive
Response content: TEST_NOK
```

Proposed output with this PR (from unit test):
```
Request retry condition met: [count=1/4], [expected-codes=[200]], [retry-codes=[500, 503]]
Request: GET /test/internalerror/resource HTTP/1.1 [Host: 127.0.0.1:32953, Connection: Keep-Alive, User-Agent: Java, Accept-Encoding: gzip,deflate, Authorization: Basic dXNlcjpwYXNz]
Response: HTTP/1.1 500 Internal Server Error [Date: Wed, 11 Jan 2023 08:39:59 GMT, Server: TEST/1.1, Content-Length: 8, Content-Type: text/plain; charset=ISO-8859-1, Connection: Keep-Alive, ]
Response Body: TEST_NOK
```


