### PR TITLE
SLING-11748 - Improve logging output of HTTP retries in testing clients

### DIFF
--- a/src/main/java/org/apache/sling/testing/clients/util/ServerErrorRetryStrategy.java
+++ b/src/main/java/org/apache/sling/testing/clients/util/ServerErrorRetryStrategy.java
@@ -96,15 +96,8 @@ public class ServerErrorRetryStrategy implements ServiceUnavailableRetryStrategy
         HttpRequestWrapper wrapper = clientContext.getAttribute(HttpClientContext.HTTP_REQUEST, HttpRequestWrapper.class);
         if (wrapper != null) {
             // Build a request detail string like following example:
-            // GET /test/internalerror/resource HTTP/1.1 [Host: 127.0.0.1:35049, Connection: Keep-Alive, User-Agent: Java,
-            //   Accept-Encoding: gzip,deflate, Authorization: Basic dXNlcjpwYXNz]
-            final StringBuilder sb = new StringBuilder(wrapper.getRequestLine().toString());
-            sb.append(" [");
-            Arrays.stream(wrapper.getAllHeaders()).forEach(header ->
-                    sb.append(header.getName()).append(": ").append(header.getValue()).append(", "));
-            sb.append("]");
-            details = sb.toString();
-
+            // GET /test/internalerror/resource HTTP/1.1
+            details = wrapper.getRequestLine().toString();
         }
         return details;
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SLING-11748

This is a follow up of #42. I came to conclude that logging the request headers is a security risk and  propose to not log the request headers at all in this context. 

@dulvac , @joerghoh: Can I please ask for  a second look? Thanks a lot. 