### PR TITLE
SLING-12576 - Update to TinyBundles 4.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,19 @@
         <dependency>
             <groupId>org.ops4j.pax.tinybundles</groupId>
             <artifactId>tinybundles</artifactId>
-            <version>3.0.0</version>
+            <version>4.0.0</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.base</groupId>
+            <artifactId>ops4j-base-store</artifactId>
+            <version>1.5.1</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>biz.aQute.bnd</groupId>
+            <artifactId>biz.aQute.bndlib</artifactId>
+            <version>6.4.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/apache/sling/testing/clients/query/QueryClient.java
+++ b/src/main/java/org/apache/sling/testing/clients/query/QueryClient.java
@@ -29,7 +29,7 @@ import org.apache.sling.testing.clients.osgi.OsgiConsoleClient;
 import org.apache.sling.testing.clients.query.servlet.QueryServlet;
 import org.apache.sling.testing.clients.util.JsonUtils;
 import org.apache.sling.testing.clients.util.URLParameterBuilder;
-import org.ops4j.pax.tinybundles.core.TinyBundles;
+import org.ops4j.pax.tinybundles.TinyBundles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -190,11 +190,11 @@ public class QueryClient extends SlingClient {
      */
     public QueryClient installServlet() throws ClientException, InterruptedException {
         InputStream bundleStream = TinyBundles.bundle()
-                .set("Bundle-SymbolicName", BUNDLE_BSN)
-                .set("Bundle-Version", BUNDLE_VERSION)
-                .set("Bundle-Name", BUNDLE_NAME)
-                .add(QueryServlet.class)
-                .build(TinyBundles.withBnd());
+                .setHeader("Bundle-SymbolicName", BUNDLE_BSN)
+                .setHeader("Bundle-Version", BUNDLE_VERSION)
+                .setHeader("Bundle-Name", BUNDLE_NAME)
+                .addClass(QueryServlet.class)
+                .build(TinyBundles.bndBuilder());
 
         try {
             File bundleFile = File.createTempFile(BUNDLE_BSN + "-" + BUNDLE_VERSION, ".jar");


### PR DESCRIPTION
Update to TinyBundles 4.0.0 and pull in the ops4-base-store and bndlib artifacts. The latest version has them set to provided scope by default.